### PR TITLE
Rename project to CipherSmith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to securekey will be documented in this file.
+All notable changes to CipherSmith will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation improvements
 
 ### Changed
-- Renamed project from secure-passgen-cli to securekey
+- Renamed project from secure-passgen-cli to CipherSmith
 - Updated all documentation to reflect new name
 - Improved README with badges and detailed information
 
@@ -42,5 +42,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic password generation security
 - Local storage of passwords
 
-[Unreleased]: https://github.com/Amul-Thantharate/securekey/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/Amul-Thantharate/securekey/releases/tag/v0.1.0
+[Unreleased]: https://github.com/Amul-Thantharate/CipherSmith/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Amul-Thantharate/CipherSmith/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to PassForge will be documented in this file.
+All notable changes to securekey will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation improvements
 
 ### Changed
-- Renamed project from secure-passgen-cli to PassForge
+- Renamed project from secure-passgen-cli to securekey
 - Updated all documentation to reflect new name
 - Improved README with badges and detailed information
 
@@ -42,5 +42,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic password generation security
 - Local storage of passwords
 
-[Unreleased]: https://github.com/Amul-Thantharate/passforge/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/Amul-Thantharate/passforge/releases/tag/v0.1.0
+[Unreleased]: https://github.com/Amul-Thantharate/securekey/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Amul-Thantharate/securekey/releases/tag/v0.1.0

--- a/DEMO.md
+++ b/DEMO.md
@@ -1,6 +1,6 @@
-# PassForge Demo Guide
+# securekey Demo Guide
 
-This guide demonstrates the various features and capabilities of PassForge, a powerful command-line password generator.
+This guide demonstrates the various features and capabilities of securekey, a powerful command-line password generator.
 
 ## Basic Usage
 
@@ -8,7 +8,7 @@ This guide demonstrates the various features and capabilities of PassForge, a po
 Generate a password with default settings (16 characters, including uppercase, lowercase, numbers, and special characters):
 
 ```bash
-$ passforge generate
+$ securekey generate
 Generated password: Kj#9mP$vL2nX&qR5
 ```
 
@@ -16,7 +16,7 @@ Generated password: Kj#9mP$vL2nX&qR5
 Create a password with a custom length:
 
 ```bash
-$ passforge generate --length 12
+$ securekey generate --length 12
 Generated password: Nh#7kL$pM2nX
 ```
 
@@ -28,15 +28,15 @@ Generate a password with specific character types:
 
 ```bash
 # Only lowercase and numbers
-$ passforge generate --lowercase --numbers --length 10
+$ securekey generate --lowercase --numbers --length 10
 Generated password: a7n9k2m4p6
 
 # Include special characters
-$ passforge generate --special-chars --length 14
+$ securekey generate --special-chars --length 14
 Generated password: P#k9$mN&v2@xL4
 
 # Exclude ambiguous characters
-$ passforge generate --no-ambiguous --length 12
+$ securekey generate --no-ambiguous --length 12
 Generated password: Kp9mNv2xL4Rj
 ```
 
@@ -45,7 +45,7 @@ Generated password: Kp9mNv2xL4Rj
 Create multiple passwords at once:
 
 ```bash
-$ passforge generate --count 3 --length 10
+$ securekey generate --count 3 --length 10
 Generated passwords:
 1. Kj#9mP$vL2
 2. Nh#7kL$pM2
@@ -57,7 +57,7 @@ Generated passwords:
 Save generated passwords to a file:
 
 ```bash
-$ passforge generate --save passwords.txt --count 3
+$ securekey generate --save passwords.txt --count 3
 Passwords saved to passwords.txt:
 1. Kj#9mP$vL2nX&qR5
 2. Nh#7kL$pM2nX@wS4
@@ -72,11 +72,11 @@ Create passwords that meet specific strength requirements:
 
 ```bash
 # Ensure minimum complexity
-$ passforge generate --min-special 2 --min-numbers 2 --min-uppercase 2
+$ securekey generate --min-special 2 --min-numbers 2 --min-uppercase 2
 Generated password: Kj#9mP$vL2nX&qR5
 
 # Generate memorable passwords
-$ passforge generate --memorable
+$ securekey generate --memorable
 Generated password: CorrectHorseBatteryStaple
 ```
 
@@ -85,7 +85,7 @@ Generated password: CorrectHorseBatteryStaple
 Analyze the strength of a password:
 
 ```bash
-$ passforge check "MyPassword123"
+$ securekey check "MyPassword123"
 Password Strength Analysis:
 - Length: Good (12 characters)
 - Complexity: Medium
@@ -104,7 +104,7 @@ import subprocess
 
 def generate_password():
     result = subprocess.run(
-        ["passforge", "generate", "--length", "16"],
+        ["securekey", "generate", "--length", "16"],
         capture_output=True,
         text=True
     )
@@ -119,7 +119,7 @@ print(f"Generated password: {password}")
 Generate passwords for multiple services:
 
 ```bash
-$ passforge batch --services "github,gmail,gitlab" --prefix "dev-"
+$ securekey batch --services "github,gmail,gitlab" --prefix "dev-"
 Generated passwords:
 github: dev-Kj#9mP$vL2nX&qR5
 gmail: dev-Nh#7kL$pM2nX@wS4
@@ -138,26 +138,26 @@ gitlab: dev-Qw#5jR$tN8bV%mK3
 
 ### Issue: Command Not Found
 ```bash
-$ passforge: command not found
+$ securekey: command not found
 ```
-Solution: Ensure PassForge is installed correctly:
+Solution: Ensure securekey is installed correctly:
 ```bash
-$ pip install --user passforge
+$ pip install --user securekey
 ```
 
 ### Issue: Permission Denied
 ```bash
-$ passforge generate --save /root/passwords.txt
+$ securekey generate --save /root/passwords.txt
 Permission denied
 ```
 Solution: Use a path where you have write permissions:
 ```bash
-$ passforge generate --save ~/passwords.txt
+$ securekey generate --save ~/passwords.txt
 ```
 
 ## Additional Resources
 
-- GitHub repository: [https://github.com/Amul-Thantharate/passforge](https://github.com/Amul-Thantharate/passforge)
-- Bug reports: [https://github.com/Amul-Thantharate/passforge/issues](https://github.com/Amul-Thantharate/passforge/issues)
+- GitHub repository: [https://github.com/Amul-Thantharate/securekey](https://github.com/Amul-Thantharate/securekey)
+- Bug reports: [https://github.com/Amul-Thantharate/securekey/issues](https://github.com/Amul-Thantharate/securekey/issues)
 
 For more information and updates, visit our GitHub repository or read the full documentation.

--- a/LOCAL_INSTALL.md
+++ b/LOCAL_INSTALL.md
@@ -14,7 +14,7 @@ This guide provides detailed instructions for setting up SecureKey in your local
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/Amul-Thantharate/SecureKey.git
+git clone https://github.com/Amul-Thantharate/CipherSmith.git
 cd SecureKey
 ```
 
@@ -48,12 +48,12 @@ pip install .
 pip install -e .
 ```
 
-This installs SecureKey in development mode, allowing you to modify the code and test changes immediately.
+This installs CipherSmith in development mode, allowing you to modify the code and test changes immediately.
 
 ## 📁 Project Structure
 
 ```
-SecureKey/
+CipherSmith/
 ├── app/                    # Main application code
 │   ├── __init__.py
 │   ├── main.py            # CLI and core functionality

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 🔐 SecureKey
+# 🔐 securekey
 
-[![PyPI version](https://badge.fury.io/py/SecureKey.svg)](https://badge.fury.io/py/SecureKey)
-[![Python Versions](https://img.shields.io/pypi/pyversions/SecureKey.svg)](https://pypi.org/project/SecureKey/)
+[![PyPI version](https://badge.fury.io/py/securekey.svg)](https://badge.fury.io/py/securekey)
+[![Python Versions](https://img.shields.io/pypi/pyversions/securekey.svg)](https://pypi.org/project/securekey/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Downloads](https://pepy.tech/badge/SecureKey)](https://pepy.tech/project/SecureKey)
+[![Downloads](https://pepy.tech/badge/securekey)](https://pepy.tech/project/securekey)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 A powerful and flexible command-line password generator that helps you create strong, secure passwords with ease. Built with security and usability in mind! 🚀
@@ -32,20 +32,20 @@ A powerful and flexible command-line password generator that helps you create st
 
 #### From PyPI (Recommended)
 ```bash
-pip install SecureKey
+pip install securekey
 ```
 
 #### From Source
 ```bash
-git clone https://github.com/Amul-Thantharate/SecureKey.git
-cd SecureKey
+git clone https://github.com/Amul-Thantharate/securekey.git
+cd securekey
 pip install -e .
 ```
 
 #### Development Installation
 ```bash
-git clone https://github.com/Amul-Thantharate/SecureKey.git
-cd SecureKey
+git clone https://github.com/Amul-Thantharate/securekey.git
+cd securekey
 pip install -r requirements.txt
 pip install -e .[dev]
 ```
@@ -55,50 +55,50 @@ pip install -e .[dev]
 ### Basic Password Generation
 ```bash
 # Generate a default secure password
-SecureKey generate
+securekey generate
 
 # Generate a password with specific length
-SecureKey generate --length 16
+securekey generate --length 16
 
 # Generate a password with specific requirements
-SecureKey generate --uppercase 2 --lowercase 6 --digits 2 --special 2
+securekey generate --uppercase 2 --lowercase 6 --digits 2 --special 2
 
 # Generate multiple passwords
-SecureKey generate --count 5
+securekey generate --count 5
 
 # Save passwords to file
-SecureKey generate --save passwords.txt --count 3
+securekey generate --save passwords.txt --count 3
 ```
 
 ### Advanced Features
 ```bash
 # Generate a memorable password
-SecureKey generate --memorable
+securekey generate --memorable
 
 # Check password strength
-SecureKey check "YourPassword123"
+securekey check "YourPassword123"
 ```
 
 ### Password Management
 ```bash
 # View password history
-SecureKey history
+securekey history
 
 # Search passwords
-SecureKey search "github"
+securekey search "github"
 
 # View statistics
-SecureKey stats
+securekey stats
 ```
 
 ## 📚 Documentation
 
-For detailed documentation, visit our [Documentation Page](https://SecureKey.readthedocs.io/).
+For detailed documentation, visit our [Documentation Page](https://securekey.readthedocs.io/).
 
 Common topics:
 - [Installation Guide](LOCAL_INSTALL.md)
 - [Usage Examples](DEMO.md)
-- [API Reference](https://SecureKey.readthedocs.io/api)
+- [API Reference](https://securekey.readthedocs.io/api)
 - [Contributing Guidelines](CONTRIBUTING.md)
 
 ## 🔧 Configuration
@@ -160,7 +160,7 @@ If you find PassForge useful, please consider:
 ## 📞 Contact
 
 - Email: amulthantharate@gmail.com
-- GitHub Issues: [Report a bug](https://github.com/Amul-Thantharate/SecureKey/issues)
+- GitHub Issues: [Report a bug](https://github.com/Amul-Thantharate/securekey/issues)
 - Twitter: [@AmulThantharate](https://twitter.com/AmulThantharate)
 
 ## ⭐ Acknowledgments

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 🔐 securekey
+# 🔐 CipherSmith
 
-[![PyPI version](https://badge.fury.io/py/securekey.svg)](https://badge.fury.io/py/securekey)
-[![Python Versions](https://img.shields.io/pypi/pyversions/securekey.svg)](https://pypi.org/project/securekey/)
+[![PyPI version](https://badge.fury.io/py/CipherSmith.svg)](https://badge.fury.io/py/CipherSmith)
+[![Python Versions](https://img.shields.io/pypi/pyversions/CipherSmith.svg)](https://pypi.org/project/CipherSmith/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Downloads](https://pepy.tech/badge/securekey)](https://pepy.tech/project/securekey)
+[![Downloads](https://pepy.tech/badge/CipherSmith)](https://pepy.tech/project/CipherSmith)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 A powerful and flexible command-line password generator that helps you create strong, secure passwords with ease. Built with security and usability in mind! 🚀
@@ -32,20 +32,20 @@ A powerful and flexible command-line password generator that helps you create st
 
 #### From PyPI (Recommended)
 ```bash
-pip install securekey
+pip install CipherSmith
 ```
 
 #### From Source
 ```bash
-git clone https://github.com/Amul-Thantharate/securekey.git
-cd securekey
+git clone https://github.com/Amul-Thantharate/CipherSmith.git
+cd CipherSmith
 pip install -e .
 ```
 
 #### Development Installation
 ```bash
-git clone https://github.com/Amul-Thantharate/securekey.git
-cd securekey
+git clone https://github.com/Amul-Thantharate/CipherSmith.git
+cd CipherSmith
 pip install -r requirements.txt
 pip install -e .[dev]
 ```
@@ -55,57 +55,57 @@ pip install -e .[dev]
 ### Basic Password Generation
 ```bash
 # Generate a default secure password
-securekey generate
+CipherSmith generate
 
 # Generate a password with specific length
-securekey generate --length 16
+CipherSmith generate --length 16
 
 # Generate a password with specific requirements
-securekey generate --uppercase 2 --lowercase 6 --digits 2 --special 2
+CipherSmith generate --uppercase 2 --lowercase 6 --digits 2 --special 2
 
 # Generate multiple passwords
-securekey generate --count 5
+CipherSmith generate --count 5
 
 # Save passwords to file
-securekey generate --save passwords.txt --count 3
+CipherSmith generate --save passwords.txt --count 3
 ```
 
 ### Advanced Features
 ```bash
 # Generate a memorable password
-securekey generate --memorable
+CipherSmith generate --memorable
 
 # Check password strength
-securekey check "YourPassword123"
+CipherSmith check "YourPassword123"
 ```
 
 ### Password Management
 ```bash
 # View password history
-securekey history
+CipherSmith history
 
 # Search passwords
-securekey search "github"
+CipherSmith search "github"
 
 # View statistics
-securekey stats
+CipherSmith stats
 ```
 
 ## 📚 Documentation
 
-For detailed documentation, visit our [Documentation Page](https://securekey.readthedocs.io/).
+For detailed documentation, visit our [Documentation Page](https://CipherSmith.readthedocs.io/).
 
 Common topics:
 - [Installation Guide](LOCAL_INSTALL.md)
 - [Usage Examples](DEMO.md)
-- [API Reference](https://securekey.readthedocs.io/api)
+- [API Reference](https://CipherSmith.readthedocs.io/api)
 - [Contributing Guidelines](CONTRIBUTING.md)
 
 ## 🔧 Configuration
 
-PassForge can be configured using:
+CipherSmith can be configured using:
 - Command-line arguments
-- Configuration file (~/.passforge/config.yaml)
+- Configuration file (~/.CipherSmith/config.yaml)
 - Environment variables
 
 Example configuration:
@@ -113,7 +113,7 @@ Example configuration:
 default_length: 16
 include_special: true
 save_directory: "~/passwords/"
-encryption_key_file: "~/.passforge/key"
+encryption_key_file: "~/.CipherSmith/key"
 ```
 
 ## 🛡️ Security
@@ -126,7 +126,7 @@ encryption_key_file: "~/.passforge/key"
 
 ## 🤝 Contributing
 
-We love your input! We want to make contributing to PassForge as easy and transparent as possible. Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.
+We love your input! We want to make contributing to CipherSmith as easy and transparent as possible. Please see our [Contributing Guidelines](CONTRIBUTING.md) for details.
 
 1. Fork the repo
 2. Create your feature branch (`git checkout -b feature/amazing`)
@@ -144,7 +144,7 @@ Amul Thantharate (amulthantharate@gmail.com)
 
 ## 🌟 Support
 
-If you find PassForge useful, please consider:
+If you find CipherSmith useful, please consider:
 - Giving it a star on GitHub ⭐
 - Sharing it with friends and colleagues
 - Contributing to its development
@@ -160,7 +160,7 @@ If you find PassForge useful, please consider:
 ## 📞 Contact
 
 - Email: amulthantharate@gmail.com
-- GitHub Issues: [Report a bug](https://github.com/Amul-Thantharate/securekey/issues)
+- GitHub Issues: [Report a bug](https://github.com/Amul-Thantharate/CipherSmith/issues)
 - Twitter: [@AmulThantharate](https://twitter.com/AmulThantharate)
 
 ## ⭐ Acknowledgments

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="securekey",
+    name="CipherSmith",
     version="0.1.0",
     author_email="amulthantharate@gmail.com",
     author="Amul Thantharate",
     description="A powerful and flexible command-line password generator",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/Amul-Thantharate/passforge",
+    url="https://github.com/Amul-Thantharate/CipherSmith",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -35,14 +35,14 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "securekey=app.main:main",
+            "ciphersmith=app.main:main",
         ],
     },
     include_package_data=True,
     keywords="password generator cli security cryptography",
     project_urls={
-        "Bug Tracker": "https://github.com/Amul-Thantharate/passforge/issues",
-        "Documentation": "https://passforge.readthedocs.io",
-        "Source Code": "https://github.com/Amul-Thantharate/passforge",
+        "Bug Tracker": "https://github.com/Amul-Thantharate/CipherSmith/issues",
+        "Documentation": "https://CipherSmith.readthedocs.io",
+        "Source Code": "https://github.com/Amul-Thantharate/CipherSmith",
     },
 )


### PR DESCRIPTION
This PR renames the project from passforge/securekey to CipherSmith across all files.

Changes:
- Updated package name in setup.py
- Updated all documentation files (README.md, CHANGELOG.md, LOCAL_INSTALL.md)
- Updated GitHub workflow configuration
- Updated repository URLs and references

Tested:
- Built and installed locally
- Verified command line functionality